### PR TITLE
use lower case

### DIFF
--- a/bttracker/tracker.go
+++ b/bttracker/tracker.go
@@ -6,7 +6,8 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+
 	"github.com/crosbymichael/tracker/registry"
 	"github.com/crosbymichael/tracker/registry/inmem"
 	"github.com/crosbymichael/tracker/registry/redis"

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
+
 	"github.com/crosbymichael/tracker/peer"
 	"github.com/crosbymichael/tracker/registry"
 )


### PR DESCRIPTION
If not, it cannot be imported in another package which uses go mod, or it would be
```
go: finding module for package github.com/Sirupsen/logrus
go: found github.com/Sirupsen/logrus in github.com/Sirupsen/logrus v1.6.0
go: found github.com/crosbymichael/tracker/registry/inmem in github.com/crosbymichael/tracker v0.0.0-20160805174527-d54763ad6ba1
go: github.com/xxxx/xxxx imports
        github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.6.0: parsing go.mod:
        module declares its path as: github.com/sirupsen/logrus
                but was required as: github.com/Sirupsen/logrus
```

Cause logrus declares it as `github.com/sirupsen/logrus`, so importing `github.com/Sirupsen/logrus` is invalid
https://github.com/sirupsen/logrus/blob/6699a89a232f3db797f2e280639854bbc4b89725/go.mod#L1

Related PR: https://github.com/sirupsen/logrus/pull/384